### PR TITLE
Rails 6.0.4 has been released

### DIFF
--- a/src/officialVersions.js
+++ b/src/officialVersions.js
@@ -8,7 +8,7 @@ export const officialVersions = {
   },
   rails: {
     latest: '6.1.3.2',
-    stables: ['6.0.3.7', '5.2.6'],
+    stables: ['6.0.4', '5.2.6'],
   },
   sinatra: {
     latest: '2.1.0',


### PR DESCRIPTION
Update Rails old-stable. 

6.0.4 does not seem to include security updates

## Reference

https://weblog.rubyonrails.org/2021/6/15/Rails-6-0-4-has-been-released/