### PR TITLE
 Rails 6.1.4 has been released

### DIFF
--- a/src/officialVersions.js
+++ b/src/officialVersions.js
@@ -7,7 +7,7 @@ export const officialVersions = {
     stables: ['2.7.3', '2.6.7'],
   },
   rails: {
-    latest: '6.1.3.2',
+    latest: '6.1.4',
     stables: ['6.0.4', '5.2.6'],
   },
   sinatra: {


### PR DESCRIPTION
Update Rails stable. 6.1.4 does not seem to include security updates.

https://weblog.rubyonrails.org/2021/6/24/Rails-6-1-4-has-been-released/